### PR TITLE
Remove language folder

### DIFF
--- a/cccyoutubefield/cccyoutubefield.xml
+++ b/cccyoutubefield/cccyoutubefield.xml
@@ -13,7 +13,6 @@
 		<filename plugin="cccyoutubefield">cccyoutubefield.php</filename>
 		<folder>css</folder>
 		<folder>js</folder>
-		<folder>language</folder>
 		<folder>tmpl</folder>
 	</files>
 </extension>


### PR DESCRIPTION
Installing the plugin doesn't work as it's trying to install a folder that doesn't exist.

Either this or you accidentally forgot to push the language folder on Github :)